### PR TITLE
use 32-bit universal hash functions for minhash

### DIFF
--- a/bottomk.go
+++ b/bottomk.go
@@ -27,6 +27,8 @@ import (
 
 type intHeap []uint64
 
+type Hash64 func([]byte) uint64
+
 func (h intHeap) Len() int { return len(h) }
 
 // actually Greater, since we want a max-heap

--- a/minwise.go
+++ b/minwise.go
@@ -1,41 +1,69 @@
 package minhash
 
-import "math"
+import (
+	"math"
+	"math/rand"
+)
+
+const (
+	// Mersenne prime for universal hash functions with 32-bit keys
+	// 2^61 - 1
+	p32     = uint64(61)
+	prime32 = uint64((1 << p32) - 1)
+)
+
+type Hash32 func([]byte) uint32
 
 // MinWise is a collection of minimum hashes for a set
 type MinWise struct {
-	minimums []uint64
-	h1       Hash64
-	h2       Hash64
+	minimums []uint32
+	h        Hash32
+	a        []uint64
+	b        []uint64
 }
 
-type Hash64 func([]byte) uint64
-
 // NewMinWise returns a new MinWise Hashsing implementation
-func NewMinWise(h1, h2 Hash64, size int) *MinWise {
+func NewMinWise(h Hash32, size int, seed int64) *MinWise {
 
-	minimums := make([]uint64, size)
-	for i := range minimums {
-		minimums[i] = math.MaxUint64
+	m := &MinWise{
+		minimums: make([]uint32, size),
+		h:        h,
+		a:        make([]uint64, size),
+		b:        make([]uint64, size),
 	}
-
-	return &MinWise{
-		h1:       h1,
-		h2:       h2,
-		minimums: minimums,
+	p := int64(prime32)
+	r := rand.New(rand.NewSource(seed))
+	for i := 0; i < size; i++ {
+		m.minimums[i] = math.MaxUint32
+		for {
+			a := r.Int63n(p)
+			if a != 0 {
+				m.a[i] = uint64(a)
+				break
+			}
+		}
+		m.b[i] = uint64(r.Int63n(p))
 	}
+	return m
 }
 
 // Push adds an element to the set.
 func (m *MinWise) Push(b []byte) {
 
-	v1 := m.h1(b)
-	v2 := m.h2(b)
-
-	for i, v := range m.minimums {
-		hv := v1 + uint64(i)*v2
-		if hv < v {
-			m.minimums[i] = hv
+	var hv, phv uint64
+	hv = uint64(m.h(b))
+	for i := range m.minimums {
+		// Because a, b, and hv are all 32-bit padded to 64-bit
+		// we can do multiplication without worrying about overflow.
+		phv = m.a[i]*hv + m.b[i]
+		// The fast way to compute phv % prime32
+		for (phv >> p32) != 0 {
+			phv = (phv & prime32) + (phv >> p32)
+		}
+		// The fast way to compute phv % 2^32
+		phv = phv & uint64(math.MaxUint32)
+		if uint32(phv) < m.minimums[i] {
+			m.minimums[i] = uint32(phv)
 		}
 	}
 }
@@ -59,14 +87,14 @@ func (m *MinWise) Cardinality() int {
 	sum := 0.0
 
 	for _, v := range m.minimums {
-		sum += -math.Log(float64(math.MaxUint64-v) / float64(math.MaxUint64))
+		sum += -math.Log(float64(math.MaxUint32-v) / float64(math.MaxUint32))
 	}
 
 	return int(float64(len(m.minimums)-1) / sum)
 }
 
 // Signature returns a signature for the set.
-func (m *MinWise) Signature() []uint64 {
+func (m *MinWise) Signature() []uint32 {
 	return m.minimums
 }
 
@@ -88,14 +116,14 @@ func (m *MinWise) Similarity(m2 *MinWise) float64 {
 	return float64(intersect) / float64(len(m.minimums))
 }
 
-// SignatureBbit returns a b-bit reduction of the signature.  This will result in unused bits at the high-end of the words if b does not divide 64 evenly.
-func (m *MinWise) SignatureBbit(b uint) []uint64 {
+// SignatureBbit returns a b-bit reduction of the signature.  This will result in unused bits at the high-end of the words if b does not divide 32 evenly.
+func (m *MinWise) SignatureBbit(b uint) []uint32 {
 
-	var sig []uint64 // full signature
-	var w uint64     // current word
-	bits := uint(64) // bits free in current word
+	var sig []uint32 // full signature
+	var w uint32     // current word
+	bits := uint(32) // bits free in current word
 
-	mask := uint64(1<<b) - 1
+	mask := uint32(1<<b) - 1
 
 	for _, v := range m.minimums {
 		if bits >= b {
@@ -105,11 +133,11 @@ func (m *MinWise) SignatureBbit(b uint) []uint64 {
 		} else {
 			sig = append(sig, w)
 			w = 0
-			bits = 64
+			bits = 32
 		}
 	}
 
-	if bits != 64 {
+	if bits != 32 {
 		sig = append(sig, w)
 	}
 
@@ -117,7 +145,7 @@ func (m *MinWise) SignatureBbit(b uint) []uint64 {
 }
 
 // SimilarityBbit computes an estimate for the similarity between two b-bit signatures
-func SimilarityBbit(sig1, sig2 []uint64, b uint) float64 {
+func SimilarityBbit(sig1, sig2 []uint32, b uint) float64 {
 
 	if len(sig1) != len(sig2) {
 		panic("signature size mismatch")
@@ -126,13 +154,13 @@ func SimilarityBbit(sig1, sig2 []uint64, b uint) float64 {
 	intersect := 0
 	count := 0
 
-	mask := uint64(1<<b) - 1
+	mask := uint32(1<<b) - 1
 
 	for i := range sig1 {
 		w1 := sig1[i]
 		w2 := sig2[i]
 
-		bits := uint(64)
+		bits := uint(32)
 
 		for bits >= b {
 			v1 := (w1 & mask)

--- a/minwisebench_test.go
+++ b/minwisebench_test.go
@@ -1,0 +1,75 @@
+package minhash
+
+import (
+	"fmt"
+	"hash/fnv"
+	"math"
+	"testing"
+)
+
+var hash32 Hash32
+
+func init() {
+	fnvHash32 := fnv.New32a()
+	hash32 = func(b []byte) uint32 {
+		fnvHash32.Reset()
+		fnvHash32.Write(b)
+		return fnvHash32.Sum32()
+	}
+}
+
+func data(size int) [][]byte {
+	d := make([][]byte, size)
+	for i := range d {
+		d[i] = []byte(fmt.Sprintf("salt%d %d", i, size))
+	}
+	return d
+}
+
+func hashing(mh *MinWise, start, end int, data [][]byte) {
+	for i := start; i < end; i++ {
+		mh.Push(data[i])
+	}
+}
+
+func benchmark(minhashSize, dataSize int) {
+	if dataSize < 10 {
+		fmt.Printf("\n")
+		return
+	}
+	// Data is a set of unique values
+	d := data(dataSize)
+	// a and b are two subsets of data with some overlaps
+	a_start, a_end := 0, int(float64(dataSize)*0.65)
+	b_start, b_end := int(float64(dataSize)*0.35), dataSize
+
+	m1 := NewMinWise(hash32, minhashSize, 0)
+	m2 := NewMinWise(hash32, minhashSize, 0)
+
+	hashing(m1, a_start, a_end, d)
+	hashing(m2, b_start, b_end, d)
+
+	est := m1.Similarity(m2)
+	act := float64(a_end-b_start) / float64(b_end-a_start)
+	err := math.Abs(act - est)
+	fmt.Printf("Data size: %8d, ", dataSize)
+	fmt.Printf("Real: %.8f, ", act)
+	fmt.Printf("Estimated: %.8f, ", est)
+	fmt.Printf("Error: %.8f\n", err)
+}
+
+func BenchmarkMinWise64(b *testing.B) {
+	benchmark(64, b.N)
+}
+
+func BenchmarkMinWise128(b *testing.B) {
+	benchmark(128, b.N)
+}
+
+func BenchmarkMinWise256(b *testing.B) {
+	benchmark(256, b.N)
+}
+
+func BenchmarkMinWise512(b *testing.B) {
+	benchmark(512, b.N)
+}


### PR DESCRIPTION
A set of 32-bit universal hash functions are cheaper to compute than the linear combination of 2 hash functions. It also gives better estimation accuracy.
