### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/minwise.go
+++ b/minwise.go
@@ -26,7 +26,7 @@ func NewMinWise(h1, h2 Hash64, size int) *MinWise {
 	}
 }
 
-// NewMinWise returns a new MinWise Hashing implementation
+// NewMinWiseFromSignatures returns a new MinWise Hashing implementation
 // using a user-provided set of signatures
 func NewMinWiseFromSignatures(h1, h2 Hash64, signatures []uint64) *MinWise {
 


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?